### PR TITLE
Add Agent QA as a related application QA tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,8 @@ A framework for testing distributed systems, which provides deterministic execut
 An implementation of POSIX threads API designed for fuzzing and debugging of concurrent programs written in C/C++ languages.
 
 ### [Tickloom](https://github.com/unmeshjoshi/tickloom)
+
+## Related application QA
+
+- [Agent QA](https://github.com/vostride/agent-qa) - A source-available QA agent for natural-language web and mobile tests. It is an adjacent application-testing tool, not a deterministic simulation testing framework.
 Tickloom is a lightweight Java framework for building deterministic, testable distributed systems.


### PR DESCRIPTION
## Summary

Add Agent QA under a clearly labeled Related application QA section.

The entry explicitly says Agent QA is not a deterministic simulation testing framework. It is proposed only as an adjacent source-available tool for natural-language web/mobile application QA, so the scope boundary remains visible to readers and reviewers.

## Validation

- confirmed no duplicate entry or proposal
- `git diff --check` passes
- canonical project link returns HTTP 200

Disclosure: I am affiliated with Agent QA.
